### PR TITLE
Add custom Tailwind palette

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,13 @@ These options can be used to customize the design and look of your StorefrontApp
 
 For interface config please reference the file `/config/defaults.js` to view options.
 
+### Custom Color Palette
+
+You can extend Tailwind's color palette from `tailwind.config.js`.
+The app includes the colors **primary**, **secondary** and **accent** which map to
+`bg-primary`, `text-secondary`, and `text-accent` utility classes. Use these
+classes in components to keep styles consistent.
+
 ### Internationalization and Translations
 
 Baked in by default StorefrontApp support internationalization and app translations. Internationalization starts from when you configure your store or network from within the Storefront extension in the [Fleetbase Console](https://console.fleetbase.io/). Read below for getting started with internationalization and translations.

--- a/src/features/Cart/screens/CartScreen.js
+++ b/src/features/Cart/screens/CartScreen.js
@@ -57,8 +57,8 @@ const RenderEmptyCartView = ({ onShopForMore }) => (
                 <Text style={tailwind('w-52 text-center text-gray-600 font-semibold')}>{translate('Cart.CartScreen.emptyStateSubtitle')}</Text>
             </View>
             <TouchableOpacity style={tailwind('w-full')} onPress={() => invoke(onShopForMore)}>
-                <View style={tailwind('flex items-center justify-center rounded-md px-8 py-2 bg-white border border-blue-500 shadow-sm')}>
-                    <Text style={tailwind('font-semibold text-blue-500 text-lg')}>{translate('Cart.CartScreen.goToBrowserButtonText')}</Text>
+                <View style={tailwind('flex items-center justify-center rounded-md px-8 py-2 bg-white border border-primary shadow-sm')}>
+                    <Text style={tailwind('font-semibold text-primary text-lg')}>{translate('Cart.CartScreen.goToBrowserButtonText')}</Text>
                 </View>
             </TouchableOpacity>
         </View>
@@ -67,7 +67,7 @@ const RenderEmptyCartView = ({ onShopForMore }) => (
 
 const RenderCartItemActions = ({ item, index, onRemoveFromCart, onEditCartItem }) => (
     <View style={tailwind('flex flex-1 items-center bg-white flex-1 flex-row justify-end')}>
-        <TouchableOpacity onPress={() => invoke(onEditCartItem, item)} style={tailwind('flex bg-blue-500 w-28 h-full items-center justify-center')}>
+        <TouchableOpacity onPress={() => invoke(onEditCartItem, item)} style={tailwind('flex bg-primary w-28 h-full items-center justify-center')}>
             <View>
                 <FontAwesomeIcon icon={faPencilAlt} size={22} style={tailwind('text-white')} />
             </View>

--- a/src/hooks/use-cart-tab-options.js
+++ b/src/hooks/use-cart-tab-options.js
@@ -5,7 +5,7 @@ import tailwind from 'tailwind';
 const useCartTabOptions = (cart) => {
     const [value, setValue] = useState({
         tabBarBadge: cart instanceof Cart ? cart.getAttribute('total_unique_items') : 0,
-        tabBarBadgeStyle: tailwind('bg-blue-500 ml-1'),
+        tabBarBadgeStyle: tailwind('bg-primary ml-1'),
     });
 
     const setCartTabOptions = (cart) => {

--- a/src/interface/ProductCard.js
+++ b/src/interface/ProductCard.js
@@ -19,7 +19,7 @@ const ProductCard = ({ product, onPress, containerStyle }) => {
                     <View style={tailwind('mb-1.5 flex flex-row items-center')}>
                         <Text style={tailwind('font-semibold')}>{translate(product, 'name')}</Text>
                         {product.getAttribute('is_service') === true && (
-                            <Text style={tailwind('ml-1 text-blue-500 font-semibold')}>{translate('components.interface.ProductCard.serviceIndicator')}</Text>
+                            <Text style={tailwind('ml-1 text-accent font-semibold')}>{translate('components.interface.ProductCard.serviceIndicator')}</Text>
                         )}
                     </View>
                     {product.getAttribute('is_available') === false && (

--- a/src/interface/widgets/StoreReviewsWidget.js
+++ b/src/interface/widgets/StoreReviewsWidget.js
@@ -171,7 +171,7 @@ const StoreReviewsWidget = ({ info, store, storeLocation, listVisible = false, w
                                 ))}
                         </View>
                     </View>
-                    <TouchableOpacity onPress={onStartReviewPress} style={tailwind('btn rounded-md bg-blue-500 px-4 py-3 shadow-sm mt-4')}>
+                    <TouchableOpacity onPress={onStartReviewPress} style={tailwind('btn rounded-md bg-primary px-4 py-3 shadow-sm mt-4')}>
                         <View style={tailwind('flex flex-row items-center')}>
                             <Text style={tailwind('text-white font-semibold')}>{translate('components.widgets.StoreReviewsWidget.writeAReview')}</Text>
                         </View>
@@ -186,7 +186,7 @@ const StoreReviewsWidget = ({ info, store, storeLocation, listVisible = false, w
                                     style={[tailwind(`btn border ${sort ? 'border-blue-300 bg-blue-50' : 'border-gray-200'} rounded-full px-4 py-2`), { width: 'auto' }]}>
                                     <View style={tailwind('flex flex-row items-center')}>
                                         <FontAwesomeIcon icon={faSort} size={12} style={tailwind('text-gray-600 mr-1')} />
-                                        <Text style={tailwind(`${sort ? 'text-blue-500' : 'text-gray-900'} font-semibold`)}>
+                                        <Text style={tailwind(`${sort ? 'text-accent' : 'text-gray-900'} font-semibold`)}>
                                             {sort ? capitalize(sort) : translate('components.widgets.StoreReviewsWidget.sort')}
                                         </Text>
                                     </View>
@@ -292,13 +292,13 @@ const StoreReviewsWidget = ({ info, store, storeLocation, listVisible = false, w
                                     .map((rating) => (
                                         <View key={rating} style={tailwind('flex flex-row border-b border-gray-100')}>
                                             <TouchableOpacity onPress={() => setFilter(rating)} style={tailwind('px-4 py-5 flex flex-row items-center justify-start w-full')}>
-                                                <Text style={tailwind('text-blue-500 font-semibold text-lg')}>{translate('Shared.StoreReviewScreen.filterOptionText', { rating })}</Text>
+                                                <Text style={tailwind('text-accent font-semibold text-lg')}>{translate('Shared.StoreReviewScreen.filterOptionText', { rating })}</Text>
                                             </TouchableOpacity>
                                         </View>
                                     ))}
                                 <View style={tailwind('flex flex-row')}>
                                     <TouchableOpacity onPress={() => setFilter(null)} style={tailwind('px-4 py-5 flex flex-row items-center justify-start w-full')}>
-                                        <Text style={tailwind('text-blue-500 font-semibold text-lg')}>{translate('Shared.StoreReviewScreen.allRatings')}</Text>
+                                        <Text style={tailwind('text-accent font-semibold text-lg')}>{translate('Shared.StoreReviewScreen.allRatings')}</Text>
                                     </TouchableOpacity>
                                 </View>
                             </View>
@@ -307,27 +307,27 @@ const StoreReviewsWidget = ({ info, store, storeLocation, listVisible = false, w
                             <View>
                                 <View style={tailwind('flex flex-row border-b border-gray-100')}>
                                     <TouchableOpacity onPress={() => setSort('newest first')} style={tailwind('px-4 py-5 flex flex-row items-center justify-start w-full')}>
-                                        <Text style={tailwind('text-blue-500 font-semibold text-lg')}>{translate('Shared.StoreReviewScreen.newestFirst')}</Text>
+                                        <Text style={tailwind('text-accent font-semibold text-lg')}>{translate('Shared.StoreReviewScreen.newestFirst')}</Text>
                                     </TouchableOpacity>
                                 </View>
                                 <View style={tailwind('flex flex-row w-full border-b border-gray-100')}>
                                     <TouchableOpacity onPress={() => setSort('oldest first')} style={tailwind('px-4 py-5 flex flex-row items-center justify-start w-full')}>
-                                        <Text style={tailwind('text-blue-500 font-semibold text-lg')}>{translate('Shared.StoreReviewScreen.oldestFirst')}</Text>
+                                        <Text style={tailwind('text-accent font-semibold text-lg')}>{translate('Shared.StoreReviewScreen.oldestFirst')}</Text>
                                     </TouchableOpacity>
                                 </View>
                                 <View style={tailwind('flex flex-row w-full border-b border-gray-100')}>
                                     <TouchableOpacity onPress={() => setSort('highest rated')} style={tailwind('px-4 py-5 flex flex-row items-center justify-start w-full')}>
-                                        <Text style={tailwind('text-blue-500 font-semibold text-lg')}>{translate('Shared.StoreReviewScreen.highestRated')}</Text>
+                                        <Text style={tailwind('text-accent font-semibold text-lg')}>{translate('Shared.StoreReviewScreen.highestRated')}</Text>
                                     </TouchableOpacity>
                                 </View>
                                 <View style={tailwind('flex flex-row w-full border-b border-gray-100')}>
                                     <TouchableOpacity onPress={() => setSort('lowest rated')} style={tailwind('px-4 py-5 flex flex-row items-center justify-start w-full')}>
-                                        <Text style={tailwind('text-blue-500 font-semibold text-lg')}>{translate('Shared.StoreReviewScreen.lowestRated')}</Text>
+                                        <Text style={tailwind('text-accent font-semibold text-lg')}>{translate('Shared.StoreReviewScreen.lowestRated')}</Text>
                                     </TouchableOpacity>
                                 </View>
                                 <View style={tailwind('flex flex-row w-full')}>
                                     <TouchableOpacity onPress={() => setSort(null)} style={tailwind('px-4 py-5 flex flex-row items-center justify-start w-full')}>
-                                        <Text style={tailwind('text-blue-500 font-semibold text-lg')}>
+                                        <Text style={tailwind('text-accent font-semibold text-lg')}>
                                             {translate('Shared.StoreReviewScreen.defaultSortOption', { networkName: info.name })}
                                         </Text>
                                     </TouchableOpacity>

--- a/styles.json
+++ b/styles.json
@@ -6194,6 +6194,18 @@
         "--tw-bg-opacity": 1,
         "backgroundColor": "rgba(131, 24, 67, var(--tw-bg-opacity))"
     },
+    "bg-primary": {
+        "--tw-bg-opacity": 1,
+        "backgroundColor": "rgba(29, 78, 216, var(--tw-bg-opacity))"
+    },
+    "bg-secondary": {
+        "--tw-bg-opacity": 1,
+        "backgroundColor": "rgba(107, 114, 128, var(--tw-bg-opacity))"
+    },
+    "bg-accent": {
+        "--tw-bg-opacity": 1,
+        "backgroundColor": "rgba(219, 39, 119, var(--tw-bg-opacity))"
+    },
     "bg-opacity-0": {
         "--tw-bg-opacity": 0
     },
@@ -7652,6 +7664,18 @@
     "text-pink-900": {
         "--tw-text-opacity": 1,
         "color": "rgba(131, 24, 67, var(--tw-text-opacity))"
+    },
+    "text-primary": {
+        "--tw-text-opacity": 1,
+        "color": "rgba(29, 78, 216, var(--tw-text-opacity))"
+    },
+    "text-secondary": {
+        "--tw-text-opacity": 1,
+        "color": "rgba(107, 114, 128, var(--tw-text-opacity))"
+    },
+    "text-accent": {
+        "--tw-text-opacity": 1,
+        "color": "rgba(219, 39, 119, var(--tw-text-opacity))"
     },
     "text-opacity-0": {
         "--tw-text-opacity": 0

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,7 +2,13 @@ module.exports = {
     purge: [],
     darkMode: false, // or 'media' or 'class'
     theme: {
-        extend: {},
+        extend: {
+            colors: {
+                primary: '#1D4ED8',
+                secondary: '#6B7280',
+                accent: '#DB2777',
+            },
+        },
     },
     variants: {
         extend: {},


### PR DESCRIPTION
## Summary
- add new `primary`, `secondary`, and `accent` colors
- update components to use `bg-primary` and `text-accent`
- document palette usage in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68434dba3fc8832b92d0ef7350df07e1