### PR TITLE
Enable media dark mode

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,6 @@
 module.exports = {
     purge: [],
-    darkMode: false, // or 'media' or 'class'
+    darkMode: 'media', // Use OS-level preference for dark mode
     theme: {
         extend: {},
     },


### PR DESCRIPTION
## Summary
- enable automatic dark mode detection in Tailwind

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68434dbcac18832ba18605494c47f997