### PR TITLE
Fix missing newline at end of AppConfig file

### DIFF
--- a/config/app.js
+++ b/config/app.js
@@ -10,3 +10,4 @@ import { configure } from './defaults';
 const AppConfig = configure('AppConfig', {});
 
 export default AppConfig;
+


### PR DESCRIPTION
## Summary
- ensure `config/app.js` ends with a newline to avoid EOF issue

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: directory not empty)*

------
https://chatgpt.com/codex/tasks/task_e_68434db646a4832b884b6c10f1450b17